### PR TITLE
Validate SSSI boolean

### DIFF
--- a/examples/examples.js
+++ b/examples/examples.js
@@ -1,15 +1,15 @@
 const { allRulesPass, runEngine, getEngine, rules } = require('../ffc-rules-engine')
 
 const parcel = {
-  ref: 'PR123',
-  totalPerimeter: 75,
-  totalArea: 7500,
-  perimeterFeatures: [],
   areaFeatures: [],
-  previousActions: [],
-  sssi: true,
+  inWaterPollutionZone: false,
   landCoverClass: 0,
-  inWaterPollutionZone: false
+  perimeterFeatures: [],
+  previousActions: [],
+  ref: 'PR123',
+  sssi: true,
+  totalArea: 7500,
+  totalPerimeter: 75
 }
 
 allRulesPass([rules.perimeter, rules.notSSSI], { parcel, quantity: 50 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neilbmclaughlin/rules-engine-test",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Test of json-rules-engine for demo ELM caculation service",
   "main": "ffc-rules-engine.js",
   "directories": {

--- a/parcel-schema.json
+++ b/parcel-schema.json
@@ -2,9 +2,30 @@
   "id": "/Parcel",
   "type": "object",
   "properties": {
-    "ref": {"type": "string"},
-    "totalPerimeter": {"type": "number"},
-    "totalArea": {"type": "number"},
+    "areaFeatures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "areaCovered": {"type": "number"},
+          "type": {"type": "string"}
+        },
+        "required": [ "type", "areaCovered" ]
+      }
+    },
+    "inWaterPollutionZone": {"type": "boolean"},
+    "landCoverClass": {"type": "integer"},
+    "perimeterFeatures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "length": {"type": "number"},
+          "type": {"type": "string"}
+        },
+        "required": [ "type", "length" ]
+      }
+    },
     "previousActions": {
       "type": "array",
       "items": {
@@ -16,40 +37,19 @@
         "required": [ "date", "identifier" ]
       }
     },
-    "perimeterFeatures": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {"type": "string"},
-          "length": {"type": "number"}
-        },
-        "required": [ "type", "length" ]
-      }
-    },
-    "areaFeatures": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "type": {"type": "string"},
-          "areaCovered": {"type": "number"}
-        },
-        "required": [ "type", "areaCovered" ]
-      }
-    },
-    "landCoverClass": {"type": "integer"},
-    "inWaterPollutionZone": {"type": "boolean"}
+    "ref": {"type": "string"},
+    "totalArea": {"type": "number"},
+    "totalPerimeter": {"type": "number"}
   },
   "required": [
-    "ref",
-    "totalPerimeter",
-    "totalArea",
-    "previousActions",
-    "perimeterFeatures",
     "areaFeatures",
-    "sssi",
+    "inWaterPollutionZone",
     "landCoverClass",
-    "inWaterPollutionZone"
+    "perimeterFeatures",
+    "previousActions",
+    "ref",
+    "sssi",
+    "totalArea",
+    "totalPerimeter"
   ]
 }

--- a/parcel-schema.json
+++ b/parcel-schema.json
@@ -38,6 +38,7 @@
       }
     },
     "ref": {"type": "string"},
+    "sssi": {"type": "boolean"},
     "totalArea": {"type": "number"},
     "totalPerimeter": {"type": "number"}
   },

--- a/test/ffc-rules-engine.test.js
+++ b/test/ffc-rules-engine.test.js
@@ -3,15 +3,15 @@ const { allRulesPass, runEngine, getEngine, rules } = require('../ffc-rules-engi
 
 function getParcelWithDefaults (options) {
   return {
-    ref: 'PR123',
-    totalPerimeter: 0,
-    totalArea: 0,
-    perimeterFeatures: [],
     areaFeatures: [],
-    previousActions: [],
-    sssi: false,
-    landCoverClass: 0,
     inWaterPollutionZone: false,
+    landCoverClass: 0,
+    perimeterFeatures: [],
+    previousActions: [],
+    ref: 'PR123',
+    sssi: false,
+    totalArea: 0,
+    totalPerimeter: 0,
     ...options
   }
 }

--- a/test/parcel-validation.test.js
+++ b/test/parcel-validation.test.js
@@ -10,15 +10,15 @@ describe('RuleEngine handles bad parcel schemas', () => {
     } catch (err) {
       expect(err.name).toBe('ParcelSchemaValidationError')
       const exepectedMissingProperties = [
-        'ref',
-        'totalPerimeter',
-        'perimeterFeatures',
-        'totalArea',
         'areaFeatures',
-        'previousActions',
-        'sssi',
+        'inWaterPollutionZone',
         'landCoverClass',
-        'inWaterPollutionZone'
+        'perimeterFeatures',
+        'previousActions',
+        'ref',
+        'sssi',
+        'totalArea',
+        'totalPerimeter'
       ]
       const missingProperties = VError.info(err).errors.map((e) => e.argument)
       expect(missingProperties.sort()).toEqual(exepectedMissingProperties.sort())
@@ -26,9 +26,14 @@ describe('RuleEngine handles bad parcel schemas', () => {
   })
   test('Should not throw for valid parcel', async () => {
     const parcel = {
-      ref: 'SD74445738',
-      totalPerimeter: 325.2,
-      totalArea: 0.656,
+      areaFeatures: [
+        {
+          type: 'pond',
+          areaCovered: 0.3
+        }
+      ],
+      inWaterPollutionZone: false,
+      landCoverClass: 0,
       perimeterFeatures: [
         {
           type: 'barn',
@@ -39,16 +44,11 @@ describe('RuleEngine handles bad parcel schemas', () => {
           length: 162.6
         }
       ],
-      areaFeatures: [
-        {
-          type: 'pond',
-          areaCovered: 0.3
-        }
-      ],
       previousActions: [],
+      ref: 'SD74445738',
       sssi: false,
-      landCoverClass: 0,
-      inWaterPollutionZone: false
+      totalArea: 0.656,
+      totalPerimeter: 325.2
     }
     expect(() => parcelValidation(parcel)).not.toThrow()
   })


### PR DESCRIPTION
Enforce that the parcel SSSI property must be boolean.

Reorder parcel schema into alphabetic order so that it is easier to find specific properties or see that one is missing.